### PR TITLE
✏ Fix link to FastAPI and Friends newsletter

### DIFF
--- a/docs/help.md
+++ b/docs/help.md
@@ -18,7 +18,7 @@ Knowing if it's useful or if you find any obvious problem with its design would 
 
 ## Subscribe to the FastAPI and Friends newsletter
 
-You can subscribe to the (infrequent) [**FastAPI and friends** newsletter](/newsletter/){.internal-link target=_blank} to stay updated about:
+You can subscribe to the (infrequent) <a href="https://fastapi.tiangolo.com/newsletter/" class="external-link" target="_blank">**FastAPI and friends**</a> to stay updated about:
 
 * News about FastAPI and friends, including Asyncer 🚀
 * Guides 📝

--- a/docs/newsletter.md
+++ b/docs/newsletter.md
@@ -1,8 +1,0 @@
-# FastAPI and friends newsletter
-
-<iframe class="mj-w-res-iframe" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://app.mailjet.com/widget/iframe/6gQ4/GDo" width="100%"></iframe>
-
-<script type="text/javascript" src="https://app.mailjet.com/statics/js/iframeResizer.min.js"></script>
-
-!!! info  
-    If you don't see the form, please disable your adblocker

--- a/docs/newsletter.md
+++ b/docs/newsletter.md
@@ -1,0 +1,8 @@
+# FastAPI and friends newsletter
+
+<iframe class="mj-w-res-iframe" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://app.mailjet.com/widget/iframe/6gQ4/GDo" width="100%"></iframe>
+
+<script type="text/javascript" src="https://app.mailjet.com/statics/js/iframeResizer.min.js"></script>
+
+!!! info  
+    If you don't see the form, please disable your adblocker


### PR DESCRIPTION
Added newsletter.md, as it is in FastAPI. 

Since uBlock origin causes the form not to load, I also added an information box:

![bilde](https://user-images.githubusercontent.com/5310116/148700759-dadd17cc-a5dd-4ece-be07-a0a7976e6949.png)


Please note I haven't used mkdocs before, and this INFO message is printed when I serve them:
```
INFO     -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
              - newsletter.md
```

Which seems fine by me, but thought I'd let you know if there is a way to silence this.

---

2022-11-04 Edit by @tiangolo: Update link to point to FastAPI and Friends newsletter.