### PR TITLE
✨ Add compatibility with the next (unreleased) version of AnyIO (4.x.x), with `get_asynclib` utility

### DIFF
--- a/asyncer/_main.py
+++ b/asyncer/_main.py
@@ -34,7 +34,7 @@ def get_asynclib(asynclib_name: Union[str, None] = None) -> Any:
     modulename = "anyio._backends._" + asynclib_name
     try:
         return sys.modules[modulename]
-    except KeyError:
+    except KeyError:  # pragma: no cover
         return import_module(modulename)
 
 


### PR DESCRIPTION
✨ Add compatibility with the next (unreleased) version of AnyIO (4.x.x), with `get_asynclib` utility