### PR TITLE
⚡ Move to Ruff and update pre-commit hooks.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,10 +21,10 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11"
       fail-fast: false
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_language_version:
     python: python3.10
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
     -   id: check-added-large-files
     -   id: check-toml
@@ -14,38 +14,20 @@ repos:
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.9.0
+    rev: v3.15.0
     hooks:
     -   id: pyupgrade
         args:
         - --py3-plus
         - --keep-runtime-typing
--   repo: https://github.com/PyCQA/autoflake
-    rev: v2.2.0
+-   repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.1.1
     hooks:
-    -   id: autoflake
+    -   id: ruff
         args:
-        - --recursive
-        - --in-place
-        - --remove-all-unused-imports
-        - --remove-unused-variables
-        - --expand-star-imports
-        - --exclude
-        - __init__.py
-        - --remove-duplicate-keys
--   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-    -   id: isort
-        name: isort (python)
-    -   id: isort
-        name: isort (cython)
-        types: [cython]
-    -   id: isort
-        name: isort (pyi)
-        types: [pyi]
+        - --fix
 -   repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.10.1
     hooks:
     -   id: black
 ci:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,22 +28,20 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = ">=3.8, <4"
 anyio = "^3.4.0"
 
-[tool.poetry.dev-dependencies]
-pytest = "^7.0.1"
-mypy = "^0.971"
-flake8 = "^5.0.4"
-black = "^22.10.0"
-pillow = "^9.3.0"
-cairosvg = "^2.5.2"
-mkdocs = "^1.2.1"
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.4.2"
+coverage = {extras = ["toml"], version = "^7.3.2"}
+black = "^23.10.1"
+mypy = "^1.6.1"
+ruff = "^0.1.1"
+cairosvg = "^2.7.1"
+pillow = "^10.1.0"
+mkdocs = "^1.5.3"
 mkdocs-material = "^8.1.4"
-mdx-include = "^1.4.1"
-coverage = {extras = ["toml"], version = "^6.2"}
-autoflake = "^1.4"
-isort = "^5.9.3"
+mdx-include = "^1.4.2"
 
 [build-system]
 requires = ["poetry-core"]
@@ -66,13 +64,6 @@ omit = [
     "docs_src/tutorial/soonify_return/tutorial002.py",
 ]
 
-[tool.isort]
-profile = "black"
-known_third_party = ["asyncer"]
-skip_glob = [
-    "asyncer/__init__.py",
-    ]
-
 
 [tool.mypy]
 strict = true
@@ -83,3 +74,22 @@ disallow_incomplete_defs = false
 disallow_untyped_defs = false
 disallow_untyped_calls = false
 warn_no_return = false
+
+[tool.ruff]
+exclude = ["__init__.py"]
+ignore = ["E501"]
+line-length = 88
+select = [
+    "B", # flake8-bugbear
+    "B9",
+    "C", # flake8-comprehensions
+    "E", # pycodestyle errors
+    "F", # pyflakes
+    "W", # pycodestyle warnings
+    "I", # isort
+]
+
+[tool.ruff.isort]
+known-third-party = [
+    "asyncer"
+]

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -4,6 +4,5 @@ set -e
 set -x
 
 mypy asyncer
-flake8 asyncer tests docs_src
+ruff check asyncer tests docs_src
 black asyncer tests docs_src --check
-isort asyncer tests docs_src scripts --check-only


### PR DESCRIPTION
# PR Details
- 👷 Move to Ruff and add pre-commit.
- ⬆ [pre-commit] pre-commit autoupdate.
- ⬆ Bump some dependencies 
- 👷 Replace python `3.11` with python `3.7` in test ci matrix
---

👷 Move to Ruff and add pre-commit.
- Ruff replaces isort, flake8, autoflake. 🚀

⬆ [pre-commit] pre-commit autoupdate.
- Upgrading pyupgrade hooks
- Upgrading black hooks
- Upgrading pre-commit hooks

⬆ Bump some dependencies 
- Set python version to `>=3.8, <4`
- Update `pillow`
- Update `pytest` & `coverage[toml]`
- Replace `ruff` with `isort` and `flake8`

👷 Replace python `3.11` with python `3.7` in test ci matrix
- [test.yml] test.yml replace python 3.11 with python 3.7 in test-ci matrix