### PR TITLE
🐛  Fix `syncify` with `raise_sync_error=False` on AnyIO 4.x.x, do not start new event loops unnecessarily

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,9 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+        anyio-version:
+          - anyio-v3
+          - anyio-v4
       fail-fast: false
 
     steps:
@@ -56,6 +59,12 @@ jobs:
       - name: Install Dependencies
         if: steps.cache.outputs.cache-hit != 'true'
         run: python -m poetry install
+      - name: Install AnyIO v3
+        if: matrix.anyio-version == 'anyio-v3'
+        run: pip install --upgrade "anyio>=3.4.0,<4.0"
+      - name: Install AnyIO v4
+        if: matrix.anyio-version == 'anyio-v4'
+        run: pip install --upgrade "anyio>=4.0.0,<5.0"
       - name: Lint
         run: python -m poetry run bash scripts/lint.sh
       - run: mkdir coverage

--- a/asyncer/_main.py
+++ b/asyncer/_main.py
@@ -13,8 +13,6 @@ from typing import (
     Union,
 )
 
-import sniffio
-
 if sys.version_info >= (3, 10):
     from typing import ParamSpec
 else:

--- a/tests/test_syncify_no_raise.py
+++ b/tests/test_syncify_no_raise.py
@@ -1,0 +1,88 @@
+import threading
+from dataclasses import dataclass
+from typing import List
+
+import anyio
+from asyncer import asyncify, syncify
+
+
+@dataclass
+class Report:
+    thread_id: int
+    caller_func: str
+
+
+
+def test_syncify_no_raise_async():
+    reports: List[Report] = []
+
+    async def do_sub_async_work():
+        report = Report(
+            thread_id=threading.get_ident(),
+            caller_func="do_sub_async_work",
+        )
+        reports.append(report)
+
+    def do_sub_sync_work():
+        report = Report(
+            thread_id=threading.get_ident(),
+            caller_func="do_sub_sync_work",
+        )
+        reports.append(report)
+        syncify(do_sub_async_work, raise_sync_error=False)()
+
+    async def do_async_work():
+        report = Report(
+            thread_id=threading.get_ident(),
+            caller_func="do_async_work",
+        )
+        reports.append(report)
+        await asyncify(do_sub_sync_work)()
+
+    def do_sync_work():
+        own_report = Report(
+            thread_id=threading.get_ident(),
+            caller_func="do_sync_work",
+        )
+        reports.append(own_report)
+        syncify(do_async_work, raise_sync_error=False)()
+
+    async def main():
+        own_report = Report(
+            thread_id=threading.get_ident(),
+            caller_func="main",
+        )
+        reports.append(own_report)
+        await asyncify(do_sync_work)()
+
+    def sync_main():
+        own_report = Report(
+            thread_id=threading.get_ident(),
+            caller_func="sync_main",
+        )
+        reports.append(own_report)
+        do_sync_work()
+
+    anyio.run(main)
+    sync_main()
+    main_thread_id = threading.get_ident()
+    assert reports[0].caller_func == "main"
+    assert reports[0].thread_id == main_thread_id
+    assert reports[1].caller_func == "do_sync_work"
+    assert reports[1].thread_id != main_thread_id
+    assert reports[2].caller_func == "do_async_work"
+    assert reports[2].thread_id == main_thread_id
+    assert reports[3].caller_func == "do_sub_sync_work"
+    assert reports[3].thread_id != main_thread_id
+    assert reports[4].caller_func == "do_sub_async_work"
+    assert reports[4].thread_id == main_thread_id
+    assert reports[5].caller_func == "sync_main"
+    assert reports[5].thread_id == main_thread_id
+    assert reports[6].caller_func == "do_sync_work"
+    assert reports[6].thread_id == main_thread_id
+    assert reports[7].caller_func == "do_async_work"
+    assert reports[7].thread_id == main_thread_id
+    assert reports[8].caller_func == "do_sub_sync_work"
+    assert reports[8].thread_id != main_thread_id
+    assert reports[9].caller_func == "do_sub_async_work"
+    assert reports[9].thread_id == main_thread_id

--- a/tests/test_syncify_no_raise.py
+++ b/tests/test_syncify_no_raise.py
@@ -12,7 +12,6 @@ class Report:
     caller_func: str
 
 
-
 def test_syncify_no_raise_async():
     reports: List[Report] = []
 

--- a/tests/test_tutorial/test_soonify_return/test_tutorial002.py
+++ b/tests/test_tutorial/test_soonify_return/test_tutorial002.py
@@ -16,10 +16,11 @@ def test_tutorial():
     new_print = get_testing_print_function(calls)
 
     with patch("builtins.print", new=new_print):
-        with pytest.raises(ExceptionGroup) as e:
+        with pytest.raises((ExceptionGroup, asyncer.PendingValueException)) as e:
             from docs_src.tutorial.soonify_return import tutorial002 as mod
 
             # Avoid autoflake removing this import
             assert mod  # pragma: nocover
-        assert isinstance(e.value.exceptions[0], asyncer.PendingValueException)
+        if isinstance(e, ExceptionGroup):
+            assert isinstance(e.value.exceptions[0], asyncer.PendingValueException)
     assert calls == []

--- a/tests/test_tutorial/test_soonify_return/test_tutorial002.py
+++ b/tests/test_tutorial/test_soonify_return/test_tutorial002.py
@@ -21,6 +21,8 @@ def test_tutorial():
 
             # Avoid autoflake removing this import
             assert mod  # pragma: nocover
-        if isinstance(e, ExceptionGroup):
+        if isinstance(e.value, ExceptionGroup):
             assert isinstance(e.value.exceptions[0], asyncer.PendingValueException)
+        else:
+            assert isinstance(e.value, asyncer.PendingValueException)
     assert calls == []


### PR DESCRIPTION
🐛  Fix `syncify` with `raise_sync_error=False` on AnyIO 4.x.x, do not start new event loops unnecessarily

Currently, when using `syncify(do_stuff, raise_sync_error=False)()` and AnyIO 4.x.x, when running on an async context (there is a parent main async function, e.g. with FastAPI), it will instead of sending the async task to the async event loop in the main thread as it should, it will start a new event loop for this async task, which is incorrect behavior when there's a parent async function, it's the correct behavior only when there's no async parent function.

This is because AnyIO 4.x.x changed the internal name `current_async_module` with `current_async_backend` and Asyncer was only checking for that.

This includes the fix and tests that verify that jumping from async to sync to async and all those possible async sandwiches behave correctly, running things in the correct thread (the main thread with the event loop or worker threads for sync functions under async parents).