### PR TITLE
🔧 Add configs for asyncer-slim

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
   release:
     types:
       - created
+  # TODO: remove this
+  push:
+    branches:
+      - slim
   workflow_dispatch:
     inputs:
       debug_enabled:
@@ -18,6 +22,7 @@ jobs:
       matrix:
         package:
           - asyncer
+          - asyncer-slim
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish
 on:
   release:
     types:
-      - created  
+      - created
   workflow_dispatch:
     inputs:
       debug_enabled:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,11 +3,7 @@ name: Publish
 on:
   release:
     types:
-      - created
-  # TODO: remove this
-  push:
-    branches:
-      - slim
+      - created  
   workflow_dispatch:
     inputs:
       debug_enabled:

--- a/.github/workflows/test-redistribute.yml
+++ b/.github/workflows/test-redistribute.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         package:
           - asyncer
+          - asyncer-slim
     steps:
       - name: Dump GitHub context
         env:

--- a/asyncer/__init__.py
+++ b/asyncer/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.6"
+__version__ = "0.0.7.dev1"
 
 from ._main import PendingValueException as PendingValueException
 from ._main import SoonValue as SoonValue

--- a/pdm_build.py
+++ b/pdm_build.py
@@ -1,0 +1,39 @@
+import os
+from typing import Any, Dict, List
+
+from pdm.backend.hooks import Context
+
+TIANGOLO_BUILD_PACKAGE = os.getenv("TIANGOLO_BUILD_PACKAGE", "asyncer")
+
+
+def pdm_build_initialize(context: Context) -> None:
+    metadata = context.config.metadata
+    # Get custom config for the current package, from the env var
+    config: Dict[str, Any] = context.config.data["tool"]["tiangolo"][
+        "_internal-slim-build"
+    ]["packages"][TIANGOLO_BUILD_PACKAGE]
+    project_config: Dict[str, Any] = config["project"]
+    # Get main optional dependencies, extras
+    optional_dependencies: Dict[str, List[str]] = metadata.get(
+        "optional-dependencies", {}
+    )
+    # Get custom optional dependencies name to always include in this (non-slim) package
+    include_optional_dependencies: List[str] = config.get(
+        "include-optional-dependencies", []
+    )
+    # Override main [project] configs with custom configs for this package
+    for key, value in project_config.items():
+        metadata[key] = value
+    # Get custom build config for the current package
+    build_config: Dict[str, Any] = (
+        config.get("tool", {}).get("pdm", {}).get("build", {})
+    )
+    # Override PDM build config with custom build config for this package
+    for key, value in build_config.items():
+        context.config.build_config[key] = value
+    # Get main dependencies
+    dependencies: List[str] = metadata.get("dependencies", [])
+    # Add optional dependencies to the default dependencies for this (non-slim) package
+    for include_optional in include_optional_dependencies:
+        optional_dependencies_group = optional_dependencies.get(include_optional, [])
+        dependencies.extend(optional_dependencies_group)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,15 @@ source-includes = [
     "scripts/",
     ]
 
+[tool.tiangolo._internal-slim-build.packages.asyncer-slim.project]
+name = "asyncer-slim"
+
+[tool.tiangolo._internal-slim-build.packages.asyncer]
+# include-optional-dependencies = ["standard"]
+
+[tool.tiangolo._internal-slim-build.packages.asyncer.project]
+optional-dependencies = {}
+
 [tool.coverage.run]
 parallel = true
 source = [


### PR DESCRIPTION
🔧 Add configs for asyncer-slim

In the future Asyncer can include the standard default recommended packages, and `asyncer-slim` can come without those recommended standard packages and with a group of optional dependencies `asyncer-slim[standard]`, equivalent to `asyncer`, for those that want to opt out of those packages.